### PR TITLE
Fix response status handling

### DIFF
--- a/locomotivecms/main.py
+++ b/locomotivecms/main.py
@@ -107,7 +107,7 @@ class LocomotiveClient(object):
             kwargs['json'] = data
             kwargs['files'] = files
         res = getattr(requests, method)(self.url + url, **kwargs)
-        if res.status_code/100 != 2:
+        if not res.ok:
             raise LocomotiveApiError(res.json(), res.status_code)
         return res.json()
 

--- a/locomotivecms/main.py
+++ b/locomotivecms/main.py
@@ -11,7 +11,7 @@ __version__ = '0.0.2'
 class LocomotiveApiError(Exception):
 
     def __init__(self, response, status_code):
-        message = response.pop('error')
+        message = response.pop('error', str(response))
         super(LocomotiveApiError, self).__init__(message)
         self.status_code = status_code
         self.extra = response


### PR DESCRIPTION
1. Fix response status handling
    
    When a resource is created, Locomotive sends back status code = 201.
    Before this change the check was failing and since there was no error
    the exception handling was broken too.
    
    Here we simply check if the status is good.

2. Make error key lookup defensive
    
    in case the error key changes, the app won't be broken.


NOTE: in the scope of shopinvader this issue leads to a broken sync of resources (eg: customers get created from shopinvader.partner but since an exception is raised the job fails and the external ID is not stored).
